### PR TITLE
[IMP] Add the commit message guidelines

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -7,6 +7,7 @@ Link to task: [#ID](https://www.odoo.com/web#model=project.task&id=)
 ### All Submissions:
 
 * [ ] My commit respects the [Odoo commit guideline](https://www.odoo.com/documentation/15.0/developer/misc/other/guidelines.html#git)
+* [ ] My commit message respects the [commit template](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)
 * [ ] I have used pre-commit
 * [ ] The PR contains **only** my modification and **no other external** commit
 


### PR DESCRIPTION
### Description

Add the commit message guidelines to the PR template as we do different commit messages from RD Team.

The commit message template used in RD Team is [this one](https://www.odoo.com/documentation/15.0/contributing/development/coding_guidelines.html#commit-message-structure).
The commit message template used in our team is [this one](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template).

To avoid any confusion, we will use the same template we decided to use, so [the PS Tech one](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template)


### Context

For https://github.com/odoo-ps/pslu-inl/pull/548 , ERL set his commit message like the template the RD Team use.
I said to him that, we do it [like this](https://github.com/odoo-ps/psbe-process/wiki/Commits-message-guidelines#template).
Then he answered me that it doesn't follow the [Odoo guidelines](https://www.odoo.com/documentation/15.0/contributing/development/coding_guidelines.html#commit-message-structure) because the `TASKID` part is not in the title.
So, to avoid any confusion, I created this PR.
